### PR TITLE
feat: add task for updating docker compose in ubuntu 18

### DIFF
--- a/edge-server/defaults/main.yml
+++ b/edge-server/defaults/main.yml
@@ -33,6 +33,9 @@ apt_packages:
   - ubuntu-drivers-common
   - wget
 
+# Docker compose version
+docker_compose_version: "v2.20.0"
+
 # Nvidia defaults
 nvidia_docker_repo_base_url: "https://nvidia.github.io/nvidia-docker"
 nvidia_docker_repo_gpg_url: "{{ nvidia_docker_repo_base_url }}/gpgkey"

--- a/edge-server/tasks/main.yml
+++ b/edge-server/tasks/main.yml
@@ -74,6 +74,18 @@
       tags:
         - docker
 
+- name: Update Docker Compose
+  when:
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_version is ansible.builtin.version('18.04')
+  tags:
+    - docker-compose
+  ansible.builtin.include_tasks:
+    file: update-docker-compose.yml
+    apply:
+      tags:
+        - docker-compose
+
 - name: Setup AWS Greengrass
   tags:
     - gg

--- a/edge-server/tasks/update-docker-compose.yml
+++ b/edge-server/tasks/update-docker-compose.yml
@@ -1,7 +1,10 @@
 - name: Uninstall docker compose
   become: true
+  with_items:
+    - docker-compose
+    - docker-compose-plugin
   ansible.builtin.apt:
-    name: "docker-compose-plugin"
+    name: "{{ item }}"
     state: "absent"
 
 - name: Check docker compose version
@@ -21,6 +24,12 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
+
+- name: Create directory if it does not exist
+  become: true
+  ansible.builtin.file:
+    path: /usr/local/lib/docker/cli-plugins
+    state: directory
 
 - name: Install docker compose
   become: true

--- a/edge-server/tasks/update-docker-compose.yml
+++ b/edge-server/tasks/update-docker-compose.yml
@@ -1,0 +1,30 @@
+- name: Uninstall docker compose
+  become: true
+  ansible.builtin.apt:
+    name: "docker-compose-plugin"
+    state: "absent"
+
+- name: Check docker compose version
+  changed_when: false
+  register: installed_docker_compose_version
+  ansible.builtin.shell: |
+    docker compose version 2>&1 | cut -d ' ' -f 4
+
+- name: Remove docker compose
+  when:
+    - installed_docker_compose_version.stdout is not ansible.builtin.version(docker_compose_version)
+  become: true
+  with_items:
+    - /usr/local/bin/docker-compose
+    - /usr/bin/docker-compose
+    - /usr/local/lib/docker/cli-plugins/docker-compose
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+
+- name: Install docker compose
+  become: true
+  ansible.builtin.get_url:
+    url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-{{ ansible_system }}-{{ ansible_architecture }}"
+    dest: /usr/local/lib/docker/cli-plugins/docker-compose
+    mode: "0755"


### PR DESCRIPTION
update docker compose version to v2.20.0 in ubuntu 18.04